### PR TITLE
forward close event

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -108,9 +108,9 @@ const WebSocket = function (url, protocols) {
         this.onopen && this.onopen();
     });
 
-    ws.addEventListener('close', () => {
+    ws.addEventListener('close', event => {
         this.readyState = this.CLOSED;
-        eventListeners.close.forEach(fn => fn());
+        eventListeners.close.forEach(fn => fn(event));
         this.onclose && this.onclose();
     });
 


### PR DESCRIPTION
Hi,
according to spec, Close listeners should receive the event. I am not sure if we need to wrap the close event from WS somehow, but this works as expected.

I am using https://github.com/vitalets/websocket-as-promised and the lack of close event is causing problems with websocket closing.